### PR TITLE
Fix two issues in DESCRIPTION preventing R CMD check

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,11 +1,11 @@
 Package: AMView
 Title: Visualizing AMU Data
-Version: 1.0
+Version: 1.0-1
 Authors@R:
     person("Wiktor", "Gustafsson", ,
     "wiktor.gustafsson@sva.se",
     role = c("aut", "cre"))
-Description: A package to visualize AMU data in an interactive Shiny app.
+Description: Visualize AMU data in an interactive Shiny app.
 License: GPL (>= 3)
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
@@ -13,6 +13,7 @@ RoxygenNote: 7.2.3
 Depends: R (>= 4.1)
 Imports:
     data.table,
+    bslib,
     DT,
     eurostat,
     htmltools,


### PR DESCRIPTION
Running R CMD check failed due to missing DESCRIPTION Imports/Depends entries: 'bslib', and also I got "The Description field should not start with the package name,  'This package' or similar." - so I changed these, hence this pull request.

There are still some issues on R CMD check that I didn't fix, but they don't seem to be critical - copied below for completeness:

Found the following file with a non-portable file name:
  inst/extdata/Content mapping AMU.xlsx
These are not fully portable file names.
See section 'Package structure' in the 'Writing R Extensions' manual.

Namespaces in Imports field not imported from:
  ‘RColorBrewer’ ‘markdown’ ‘sf’
  All declared Imports should be used.

checking R code for possible problems ... NOTE
amu_dummy_data: no visible binding for global variable ‘atc_code’
amu_dummy_data : <anonymous> : <anonymous>: no visible global function
  definition for ‘runif’
map_server : <anonymous> : <anonymous>: no visible global function
  definition for ‘write.csv’
trends_server : <anonymous> : <anonymous>: no visible global function
  definition for ‘write.csv’
Undefined global functions or variables:
  atc_code runif write.csv
Consider adding
  importFrom("stats", "runif")
  importFrom("utils", "write.csv")
to your NAMESPACE file.

checking Rd \usage sections ... WARNING
Undocumented arguments in documentation object 'app_server'
  ‘input’ ‘output’ ‘session’

These should be relatively easy to fix, so if you do so then just let me know and I will pull the changes to the forked repo before creating the DOI.

The following are obviously harder to fix:

checking installed package size ... NOTE
  installed size is 23.8Mb
  sub-directories of 1Mb or more:
    extdata  23.6Mb

checking for code which exercises the package ... WARNING
No examples, no tests, no vignettes

Hope this is helpful.